### PR TITLE
Fix https://github.com/kixe/FieldtypeSelectExtOption/issues/19

### DIFF
--- a/FieldtypeSelectExtOption.module
+++ b/FieldtypeSelectExtOption.module
@@ -624,46 +624,54 @@ class FieldtypeSelectExtOption extends FieldtypeMulti {
 	 */
 	protected function getEqualValue(Page $page, Field $field, $value) {
 
-		// receive current page value (SelectExtOption or SelectExtOptionArray) from data array
-		$_value = isset($page->data[$field->name]) ? $page->data[$field->name] : null;
-		if (!$_value) return $value;
-
-		// $this->error('changed');
-
-		$int1 = null;
-		$int2 = null;
-		$array1 = [];
-		$array2 = [];
-
-		// $this->error('changed');
-
-		if ($value instanceof SelectExtOption) $int1 = $value->value;
-		if ($value instanceof SelectExtOptionArray) $array1 = array_values($value->each('value'));
-
-		if ($_value instanceof SelectExtOption) $int2 = $_value->value;
-		if ($_value instanceof SelectExtOptionArray) $array2 = array_values($_value->each('value'));
-
-		if (is_numeric($value)) $int1 = (int) $value;
-		if (is_array($value)) {
-			foreach ($value as $key => $item) {
-				if ($item instanceof SelectExtOption) $array1[] = $item->value;
-				else if (is_numeric($item)) $array1[] = (int) $item;
-			}
-		}
-
-		$array1 = array_unique($array1);
-		$array2 = array_unique($array2);
-
-		// sortable?
-		$module = $this->modules->get($field->input_type);
-		$sortable = ($module instanceof InputfieldHasArrayValue && $module instanceof InputfieldHasSortableValue)? true : false;
-		if (!$sortable) {
-			sort($array1);
-			sort($array2);
-		}
-
-		if ($array1 === $array2 && $int1 === $int2) return $_value;
-		return $value;
+	    // receive current page value (SelectExtOption or SelectExtOptionArray) from data array
+	    $_value = isset($page->data[$field->name]) ? $page->data[$field->name] : null;
+	    if (!$_value) return $value;
+	
+	    $int1 = null;
+	    $int2 = null;
+	    $array1 = [];
+	    $array2 = [];
+	
+	    if ($value instanceof SelectExtOption) {
+	        $int1 = $value->value;
+	    } elseif ($value instanceof SelectExtOptionArray) {
+	        foreach ($value as $item) {
+	            $array1[] = $item->value;
+	        }
+	    } elseif (is_array($value)) {
+	        foreach ($value as $item) {
+	            if ($item instanceof SelectExtOption) {
+	                $array1[] = $item->value;
+	            } elseif (is_numeric($item)) {
+	                $array1[] = (int)$item;
+	            }
+	        }
+	    } elseif (is_numeric($value)) {
+	        $int1 = (int)$value;
+	    }
+	
+	    if ($_value instanceof SelectExtOption) {
+	        $int2 = $_value->value;
+	    } elseif ($_value instanceof SelectExtOptionArray) {
+	        foreach ($_value as $item) {
+	            $array2[] = $item->value;
+	        }
+	    }
+	
+	    $array1 = array_unique($array1);
+	    $array2 = array_unique($array2);
+	
+	    // sortable?
+	    $module = $this->modules->get($field->input_type);
+	    $sortable = ($module instanceof InputfieldHasArrayValue && $module instanceof InputfieldHasSortableValue) ? true : false;
+	    if (!$sortable) {
+	        sort($array1);
+	        sort($array2);
+	    }
+	
+	    if ($array1 === $array2 && $int1 === $int2) return $_value;
+	    return $value;
 	}
 
 	public function getBlankValue(Page $page, Field $field) {


### PR DESCRIPTION
Replaced each('value') with Manual Loops:
For both $value and $_value, if they are instances of SelectExtOptionArray, we iterate over each item and collect the value property into $array1 or $array2.

Handled Different Value Types:
Properly checks if $value is a SelectExtOption, SelectExtOptionArray, array, or numeric, and processes each case to build $array1 and $int1 accordingly.

This approach ensures that we're working with plain PHP arrays, preventing the type error when using array_values().